### PR TITLE
encampments: cope with missing needs...

### DIFF
--- a/Source/VOE/Outpost_Encampment.cs
+++ b/Source/VOE/Outpost_Encampment.cs
@@ -11,8 +11,10 @@ namespace VOE
             if (Packing) return;
             foreach (var pawn in AllPawns)
             {
-                pawn.needs.food.CurLevel += Need_Food.BaseFoodFallPerTick;
-                pawn.needs.rest.CurLevel += Need_Rest.BaseRestGainPerTick;
+                if (pawn.needs.food != null)
+                    pawn.needs.food.CurLevel += Need_Food.BaseFoodFallPerTick;
+                if (pawn.needs.rest != null)
+                    pawn.needs.rest.CurLevel += Need_Rest.BaseRestGainPerTick;
                 if (pawn.health.HasHediffsNeedingTend())
                     foreach (var hediff in pawn.health.hediffSet.GetHediffsTendable())
                         hediff.Tended(1f, 1f);


### PR DESCRIPTION
Some Pawns, often robots, don't have a sleep or food need.
This updates the Encampment outpost to recognise that, and 
ignore them in the adjustments.

Tested locally with "Android Tiers++", but it should apply
to any race that is missing the needs.